### PR TITLE
Fix detection of previous PR annotation comments 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.21.2
+version=1.21.3
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClient.java
@@ -133,11 +133,12 @@ public class GraphqlGithubClient implements GithubClient {
 
         GetRepository.PullRequest pullRequest = getPullRequest(graphqlUrl, headers, pullRequestKey);
         String pullRequestId = pullRequest.getId();
+        String projectCommentMarker = String.format("**Project ID:** %s%n", projectId);
 
         getComments(pullRequest, graphqlUrl, headers, pullRequestKey).stream()
             .filter(c -> "Bot".equalsIgnoreCase(c.getAuthor().getType()) && login.equalsIgnoreCase(c.getAuthor().getLogin()))
             .filter(c -> !c.isMinimized())
-            .filter(c -> c.getBody().contains(String.format("**Project ID:** %s\r\n", projectId)))
+            .filter(c -> c.getBody().contains(projectCommentMarker))
             .map(Comments.CommentNode::getId)
             .forEach(commentId -> this.minimizeComment(graphqlUrl, headers, commentId));
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClientTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClientTest.java
@@ -148,6 +148,7 @@ class GraphqlGithubClientTest {
         ArgumentCaptor<GraphQLRequestEntity> getViewer = ArgumentCaptor.forClass(GraphQLRequestEntity.class);
         when(graphQLTemplate.query(getViewer.capture(), eq(Viewer.class))).thenReturn(viewerResponseEntity);
 
+        String bodyString = objectMapper.writeValueAsString("**Project ID:** project-key-test" + System.lineSeparator());
         GraphQLResponseEntity<GetRepository> getPullRequestResponseEntity =
             objectMapper.readValue("{" +
                 "\"response\": " +
@@ -159,7 +160,7 @@ class GraphqlGithubClientTest {
                 "          {" +
                 "            \"id\": \"MDEyOklzc3VlQ29tbWVudDE1MDE3\"," +
                 "            \"isMinimized\": false," +
-                "            \"body\": \"**Project ID:** project-key-test\\r\\n\"," +
+                "            \"body\": " + bodyString + "," +
                 "            \"author\": {" +
                 "              \"__typename\": \"Bot\"," +
                 "              \"login\": \"test-sonar\"" +


### PR DESCRIPTION
This change resolves the issue where SonarQube summary comments in GitHub pull request conversations are not hidden, leaving only the current summary.

**Ref:** [mc1arke/sonarqube-community-branch-plugin#898](https://github.com/mc1arke/sonarqube-community-branch-plugin/pull/898)